### PR TITLE
Show preview images until the real images have loaded

### DIFF
--- a/src/lib/components/kurosearch/media-gif/Gif.svelte
+++ b/src/lib/components/kurosearch/media-gif/Gif.svelte
@@ -29,7 +29,7 @@
 	<img
 		class="post-media media-img"
 		loading="lazy"
-		data-src={data_src}
+		data-src-lowres={data_src}
 		alt={post.id.toString()}
 		width={post.width}
 		height={post.height}

--- a/src/lib/components/kurosearch/media-image/Image.svelte
+++ b/src/lib/components/kurosearch/media-image/Image.svelte
@@ -4,7 +4,6 @@
 	import { postobserve } from '$lib/logic/use/postobserve';
 	import highResolutionEnabled from '$lib/store/high-resolution-enabled';
 	import { calculateAspectRatio, calculateAspectRatioCss } from '../post/ratio';
-	import { onMount } from 'svelte';
 
 	export let post: kurosearch.Post;
 
@@ -12,18 +11,6 @@
 	let expandable = ratio < 0.33;
 
 	let open: boolean;
-
-	onMount(() => {
-		console.log(post.id, 'started loading full');
-		const fullImgElem: HTMLImageElement = new Image();
-		fullImgElem.src = highResolutionEnabled ? post.file_url : post.sample_url;
-		fullImgElem.onload = () => {
-			src = fullImgElem.currentSrc;
-			console.log(post.id, 'replaced full');
-		};
-	});
-
-	$: src = post.preview_url;
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -35,8 +22,8 @@
 	<img
 		class="post-media"
 		loading="lazy"
-		{src}
-		data-src={src}
+		data-src-lowres={post.preview_url}
+		data-src-hires={highResolutionEnabled ? post.file_url : post.sample_url}
 		alt={post.id.toString()}
 		style="aspect-ratio: {calculateAspectRatioCss(post.width, post.height)}"
 		width={post.width}

--- a/src/lib/components/kurosearch/media-image/Image.svelte
+++ b/src/lib/components/kurosearch/media-image/Image.svelte
@@ -4,6 +4,7 @@
 	import { postobserve } from '$lib/logic/use/postobserve';
 	import highResolutionEnabled from '$lib/store/high-resolution-enabled';
 	import { calculateAspectRatio, calculateAspectRatioCss } from '../post/ratio';
+	import { onMount } from 'svelte';
 
 	export let post: kurosearch.Post;
 
@@ -12,7 +13,17 @@
 
 	let open: boolean;
 
-	$: src = highResolutionEnabled ? post.file_url : post.sample_url;
+	onMount(() => {
+		console.log(post.id, 'started loading full');
+		const fullImgElem: HTMLImageElement = new Image();
+		fullImgElem.src = highResolutionEnabled ? post.file_url : post.sample_url;
+		fullImgElem.onload = () => {
+			src = fullImgElem.currentSrc;
+			console.log(post.id, 'replaced full');
+		};
+	});
+
+	$: src = post.preview_url;
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -24,6 +35,7 @@
 	<img
 		class="post-media"
 		loading="lazy"
+		{src}
 		data-src={src}
 		alt={post.id.toString()}
 		style="aspect-ratio: {calculateAspectRatioCss(post.width, post.height)}"

--- a/src/lib/logic/post-observer.ts
+++ b/src/lib/logic/post-observer.ts
@@ -6,11 +6,18 @@ export const postObserver = browser
 	? new IntersectionObserver(
 		(entries) => {
 			for (const entry of entries) {
-				const lowSrc = entry.target.getAttribute('data-src-lowres') ?? '';
-				const highSrc = entry.target.getAttribute('data-src-hires') ?? '';
-
+				//check if post is visible
 				if (entry.isIntersecting) {
+					//fetch source urls saved in the image data attributes
+					const lowSrc = entry.target.getAttribute('data-src-lowres') ?? '';
+					const highSrc = entry.target.getAttribute('data-src-hires') ?? '';
+
+					//set post.preview_url to image sources or sources.static to gifs
 					entry?.target?.setAttribute('src', lowSrc);
+
+					//data-src-hires only exists on static images so skip the rest of the function on gifs
+					if (highSrc === '') return;
+					//create new non-visible image and swap the sources once loaded
 					const fullImage = new Image();
 					fullImage.src = highSrc;
 					fullImage.onload = () => {

--- a/src/lib/logic/post-observer.ts
+++ b/src/lib/logic/post-observer.ts
@@ -4,12 +4,21 @@ const rootMargin = '1250px';
 
 export const postObserver = browser
 	? new IntersectionObserver(
-			(entries) => {
-				for (const entry of entries) {
-					const newSrc = entry.isIntersecting ? entry.target.getAttribute('data-src') ?? '' : '';
-					entry?.target?.setAttribute('src', newSrc);
+		(entries) => {
+			for (const entry of entries) {
+				const lowSrc = entry.target.getAttribute('data-src-lowres') ?? '';
+				const highSrc = entry.target.getAttribute('data-src-hires') ?? '';
+
+				if (entry.isIntersecting) {
+					entry?.target?.setAttribute('src', lowSrc);
+					const fullImage = new Image();
+					fullImage.src = highSrc;
+					fullImage.onload = () => {
+						entry.target.setAttribute('src', fullImage.src);
+					}
 				}
-			},
-			{ rootMargin }
-	  )
+			}
+		},
+		{ rootMargin }
+	)
 	: null;

--- a/src/lib/logic/post-observer.ts
+++ b/src/lib/logic/post-observer.ts
@@ -12,6 +12,9 @@ export const postObserver = browser
 					const lowSrc = entry.target.getAttribute('data-src-lowres') ?? '';
 					const highSrc = entry.target.getAttribute('data-src-hires') ?? '';
 
+					//when the image comes in and goes out of the viewport this prevents reloading the already loaded sources
+					if (entry.target.getAttribute('src') === highSrc) return;
+
 					//set post.preview_url to image sources or sources.static to gifs
 					entry?.target?.setAttribute('src', lowSrc);
 


### PR DESCRIPTION
Changes only how images work since gifs and videos had custom logic and most gifs already use the preview_url as the thumbnail. I did not add styling since I don't think it's needed. Only issue I found during testing was that when using firefox the src would just randomly not get set even though the links were correct and the interceptionObserver was triggered. This was with heavy network throttling and no cache enabled. The images that failed to get src would eventually load skipping the preview source completely. 