### PR TITLE
fix: mobile image stretching in fullscreen viewer

### DIFF
--- a/src/lib/components/kurosearch/fullscreen-post/FullscreenGif.svelte
+++ b/src/lib/components/kurosearch/fullscreen-post/FullscreenGif.svelte
@@ -155,10 +155,9 @@
 
 <style>
 	img {
-		display: flex;
+		display: block;
 		width: 100vw;
 		height: 100vh;
 		object-fit: contain;
-		contain: strict;
 	}
 </style>

--- a/src/lib/components/kurosearch/fullscreen-post/FullscreenImage.svelte
+++ b/src/lib/components/kurosearch/fullscreen-post/FullscreenImage.svelte
@@ -158,8 +158,8 @@
 <style>
 	img {
 		display: block;
-		width: 100dvw;
-		height: 100dvh;
+		width: 100vw;
+		height: 100vh;
 		object-fit: contain;
 	}
 </style>

--- a/src/lib/components/kurosearch/fullscreen-post/FullscreenImage.svelte
+++ b/src/lib/components/kurosearch/fullscreen-post/FullscreenImage.svelte
@@ -157,10 +157,9 @@
 
 <style>
 	img {
-		display: flex;
-		width: 100vw;
-		height: 100vh;
+		display: block;
+		width: 100dvw;
+		height: 100dvh;
 		object-fit: contain;
-		contain: strict;
 	}
 </style>


### PR DESCRIPTION
## Bug
Images appear stretched when viewed in fullscreen on mobile browsers.
Works correctly on desktop.

## Root Cause
`contain: strict` is set on the `<img>` elements in `FullscreenImage.svelte` and `FullscreenGif.svelte`.

`contain: strict` includes `contain: size`, which causes the browser to ignore the image's intrinsic dimensions. This means `object-fit: contain` cannot determine the aspect ratio and stretches the image to fill the box instead of letterboxing it.

## Fix
Remove `contain: strict` from the `img` CSS in:
- `src/lib/components/kurosearch/fullscreen-post/FullscreenImage.svelte`
- `src/lib/components/kurosearch/fullscreen-post/FullscreenGif.svelte`