### PR TITLE
BUGFIX: Update preloaded URLs based on user scroll position

### DIFF
--- a/src/lib/components/kurosearch/fullscreen-post/FullscreenScroller.svelte
+++ b/src/lib/components/kurosearch/fullscreen-post/FullscreenScroller.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import IntersectionDetector from '$lib/components/pure/intersection-detector/IntersectionDetector.svelte';
 	import autoplayFullscreenEnabled from '$lib/store/autoplay-fullscreen-enabled-store';
+	import highResolutionEnabled from '$lib/store/high-resolution-enabled';
 	import results from '$lib/store/results-store';
 	import { onDestroy, onMount } from 'svelte';
 	import Screen from './Screen.svelte';
+
 
 	interface Props {
 		index: number;
@@ -52,6 +54,19 @@
 		}
 	};
 
+	let preloadUrls = $derived.by(() => {
+		const posts = $results.posts;
+		const hi = $highResolutionEnabled;
+		const urls: string[] = [];
+		for (let i = Math.max(0, desiredIndex - 1); i <= Math.min(posts.length - 1, desiredIndex + 2); i++) {
+			const post = posts[i];
+			if (post.type === 'video') continue;
+			urls.push(hi ? post.file_url : post.sample_url);
+			urls.push(post.preview_url);
+		}
+		return urls.filter(Boolean);
+	});
+
 	onMount(() => {
 		container.scrollTop = desiredIndex * window.innerHeight;
 		document.addEventListener('keydown', keybinds);
@@ -65,6 +80,12 @@
 	{@html message}
 </p> -->
 
+<div class="preload" aria-hidden="true">
+	{#each preloadUrls as url (url)}
+		<img src={url} alt="" />
+	{/each}
+</div>
+
 <div class="root screen snap-container" bind:this={container} {onscroll}>
 	<Screen offset={0} step={3} index={desiredIndex} onended={autoscroll} {startAt} />
 	<Screen offset={1} step={3} index={desiredIndex} onended={autoscroll} {startAt} />
@@ -77,6 +98,17 @@
 </div>
 
 <style>
+	.preload {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
+		pointer-events: none;
+		z-index: -1;
+	}
+
 	.root {
 		position: relative;
 		overflow-y: scroll;


### PR DESCRIPTION
## Bug
Images fail to load when scrolling to unvisited posts in the fullscreen viewer on iOS.
Works correctly if the image was previously visible in the results grid.

## Root Cause
The fullscreen viewer positions screens using `transform: translateY()`. iOS WebKit does not load images inside elements that are off-screen via CSS transforms, so only images already in the browser cache (from being viewed in the grid) appear.

`new Image()` does not reliably fix this — iOS can deprioritize or skip fetches for images that aren't attached to the DOM.

## Fix
Add a `position: fixed` hidden container in `FullscreenScroller.svelte` that holds real `<img>` elements for adjacent posts. Since the container is always in the viewport, iOS is forced to load them. The preloaded URLs update reactively as the user scrolls, keeping the next and previous posts ready.