### PR TITLE
fix: resolve Svelte 5 state_referenced_locally build warnings

### DIFF
--- a/src/lib/components/kurosearch/dialog-edit-supertag/EditSupertagDialog.svelte
+++ b/src/lib/components/kurosearch/dialog-edit-supertag/EditSupertagDialog.svelte
@@ -18,7 +18,11 @@
 
 	const emitEdit = () => onedit(supertag.name, newSupertag);
 
-	let newSupertag = $state({ ...supertag, tags: [...supertag.tags] });
+	let newSupertag: kurosearch.Supertag = $state(undefined!);
+	$effect(() => {
+		newSupertag = { ...supertag, tags: [...supertag.tags] };
+	});
+
 </script>
 
 <Dialog bind:dialog {onclose}>

--- a/src/lib/components/pure/intersection-detector/IntersectionDetector.svelte
+++ b/src/lib/components/pure/intersection-detector/IntersectionDetector.svelte
@@ -5,18 +5,16 @@
 	 */
 	let { rootMargin, absoluteTop, onintersection } = $props();
 
-
-	const intersectionObserver = new IntersectionObserver(
-		(entries) => {
-			if (entries[0].isIntersecting) {
-				onintersection();
-			}
-		},
-		{ rootMargin }
-	);
-
 	let ref: HTMLDivElement;
 	$effect(() => {
+		const intersectionObserver = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting) {
+					onintersection();
+				}
+			},
+			{ rootMargin }
+		);
 		if (ref) {
 			intersectionObserver.observe(ref);
 		}


### PR DESCRIPTION
Clears compile-time warnings by moving non-reactive state declarations inside closures ($effect) and initializing mutable dialog properties cleanly.